### PR TITLE
Outdated packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Ignore editor's settings file
+.vscode/
+

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,28 +1,6 @@
-import {wait} from '../src/wait'
-import * as process from 'process'
-import * as cp from 'child_process'
-import * as path from 'path'
-
-test('throws invalid number', async () => {
-  const input = parseInt('foo', 10)
-  await expect(wait(input)).rejects.toThrow('milliseconds not a number')
-})
-
-test('wait 500 ms', async () => {
-  const start = new Date()
-  await wait(500)
-  const end = new Date()
-  var delta = Math.abs(end.getTime() - start.getTime())
-  expect(delta).toBeGreaterThan(450)
-})
-
-// shows how the runner will run a javascript action with env / stdout protocol
-test('test runs', () => {
-  process.env['INPUT_MILLISECONDS'] = '500'
-  const np = process.execPath
-  const ip = path.join(__dirname, '..', 'lib', 'main.js')
-  const options: cp.ExecFileSyncOptions = {
-    env: process.env
-  }
-  console.log(cp.execFileSync(np, [ip], options).toString())
+describe.skip('will be implemented', () => {
+  it('add', function () {
+    const result = 5 + 2
+    expect(result).toBe(7)
+  })
 })

--- a/__tests__/outdated.test.ts
+++ b/__tests__/outdated.test.ts
@@ -1,0 +1,126 @@
+import * as outdated from '../src/outdated'
+
+describe('splitAndRemoveEmptyString', () => {
+  it('split a long string into string[] and remove empty string', () => {
+    const longStringWithExtraEmptySpaces =
+      'Lorem   ipsum  dolor  sit   amet   consectetur  adipiscing  elit'
+    const result = outdated.splitAndRemoveEmptyString(
+      longStringWithExtraEmptySpaces,
+      ' '
+    )
+    const expectedResult = [
+      'Lorem',
+      'ipsum',
+      'dolor',
+      'sit',
+      'amet',
+      'consectetur',
+      'adipiscing',
+      'elit'
+    ]
+    expect(result).toStrictEqual(expectedResult)
+  })
+})
+
+describe('parseIntoPackageVersionInfo', () => {
+  it('convert an array of string (length of 5) into PackageVersionInfo', () => {
+    const arrayOfString = ['Donec', 'nec', 'libero', 'et', 'lorem']
+    const result = outdated.parseIntoPackageVersionInfo(arrayOfString)
+    const expectedResult: outdated.PackageVersionInfo = {
+      packageName: 'Donec',
+      currentVersion: 'nec',
+      upgradableVersion: 'libero',
+      resolvableVersion: 'et',
+      latestVersion: 'lorem'
+    }
+
+    expect(result).toStrictEqual(expectedResult)
+  })
+})
+
+describe('parseIntoDependencySection', () => {
+  it('convert an array of string (without the first element) into DependencySection', () => {
+    const arrayOfString = [
+      'Phasellus vel mauris nec massa',
+      'Nulla id dui malesuada lacus porttitor pulvinar',
+      'Nullam ac dolor ac sapien'
+    ]
+    const result = outdated.parseIntoDependencySection(arrayOfString)
+    const expectedResult: outdated.DependencySection = [
+      {
+        packageName: 'Phasellus',
+        currentVersion: 'vel',
+        upgradableVersion: 'mauris',
+        resolvableVersion: 'nec',
+        latestVersion: 'massa'
+      },
+      {
+        packageName: 'Nullam',
+        currentVersion: 'ac',
+        upgradableVersion: 'dolor',
+        resolvableVersion: 'ac',
+        latestVersion: 'sapien'
+      }
+    ]
+
+    expect(result).toStrictEqual(expectedResult)
+  })
+})
+
+describe('splitIntoDependencySections', () => {
+  it('convert an multiline string into 4 DependencySections', () => {
+    const multiLineString = `
+      Dependencies
+      Cras a diam pellentesque imperdiet
+      dev_dependencies
+      Sed gravida ligula sit amet
+      transitive dependencies
+      Curabitur eleifend diam at egestas
+      transitive dev_dependencies
+      Sed dignissim nunc et velit
+      Mauris sed nulla et risus placerat blandit vel non turpis
+    `
+    const result = outdated.splitIntoDependencySections(multiLineString)
+    const expectedResult: outdated.DependencySection[] = [
+      [
+        {
+          packageName: 'Cras',
+          currentVersion: 'a',
+          upgradableVersion: 'diam',
+          resolvableVersion: 'pellentesque',
+          latestVersion: 'imperdiet'
+        }
+      ],
+      [
+        {
+          packageName: 'Sed',
+          currentVersion: 'gravida',
+          upgradableVersion: 'ligula',
+          resolvableVersion: 'sit',
+          latestVersion: 'amet'
+        }
+      ],
+      [
+        {
+          packageName: 'Curabitur',
+          currentVersion: 'eleifend',
+          upgradableVersion: 'diam',
+          resolvableVersion: 'at',
+          latestVersion: 'egestas'
+        }
+      ],
+      [
+        {
+          packageName: 'Sed',
+          currentVersion: 'dignissim',
+          upgradableVersion: 'nunc',
+          resolvableVersion: 'et',
+          latestVersion: 'velit'
+        }
+      ]
+    ]
+
+    expect(result.length).toStrictEqual(4)
+    expect(result).toStrictEqual(expectedResult)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.2.6"
+        "@actions/core": "^1.2.6",
+        "@actions/exec": "^1.0.4"
       },
       "devDependencies": {
         "@types/jest": "^26.0.15",
@@ -31,6 +32,19 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.4.tgz",
+      "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
+      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.5.5",
@@ -10557,6 +10571,19 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "@actions/exec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.4.tgz",
+      "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "@actions/io": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
+      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.6"
+    "@actions/core": "^1.2.6",
+    "@actions/exec": "^1.0.4"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import * as core from '@actions/core'
-import {outdatedPackages} from './outdated'
+import {getOutdatedPackages} from './outdated'
 
 async function run(): Promise<void> {
   try {
-    await outdatedPackages()
+    await getOutdatedPackages()
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import * as core from '@actions/core'
-import { outdatedPackages } from "./outdated";
+import {outdatedPackages} from './outdated'
 
 async function run(): Promise<void> {
   try {
-      await outdatedPackages();
+    await outdatedPackages()
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,9 @@
 import * as core from '@actions/core'
-import {wait} from './wait'
+import { outdatedPackages } from "./outdated";
 
 async function run(): Promise<void> {
   try {
-    const ms: string = core.getInput('milliseconds')
-    core.debug(`Waiting ${ms} milliseconds ...`) // debug is only output if you set the secret `ACTIONS_RUNNER_DEBUG` to true
-
-    core.debug(new Date().toTimeString())
-    await wait(parseInt(ms, 10))
-    core.debug(new Date().toTimeString())
-
-    core.setOutput('time', new Date().toTimeString())
+      await outdatedPackages();
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,8 @@ import {getOutdatedPackages} from './outdated'
 
 async function run(): Promise<void> {
   try {
-    await getOutdatedPackages()
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const outdatedPackages = await getOutdatedPackages()
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,0 +1,126 @@
+import { exec, ExecOptions } from "@actions/exec";
+
+// TODO: add tests
+
+export async function outdatedPackages() {
+    let output = '';
+    let error = '';
+
+    const options: ExecOptions = {};
+    options.silent = true;
+    options.listeners = {
+        stdout: (data: Buffer) => {
+            output += data.toString();
+        },
+        stderr: (data: Buffer) => {
+            error += data.toString();
+        }
+    };
+
+    await exec('flutter', ['pub', 'outdated'], options);
+
+    // TODO: error handling when error is emptyString
+    console.log(error);
+
+    let dependencies = parseFlutterPubOutdatedOutput(output);
+
+    // TODO: only returns dependencies and devDependencies
+    console.log(dependencies);
+}
+
+function parseFlutterPubOutdatedOutput(outputFromConsole: string): Dependencies {
+    let dependencySections = splitIntoDependencySections(outputFromConsole);
+
+    return {
+        dependencies: dependencySections[0],
+        devDependencies: dependencySections[1],
+        transitiveDependencies: dependencySections[2],
+        transitiveDevDependencies: dependencySections[3]
+    };
+}
+
+function splitIntoDependencySections(fullText: string): DependencySection[] {
+    // title of each dependency section
+    const dependencySections = ['Dependencies', 'dev_dependencies', 'transitive dependencies', 'transitive dev_dependencies'];
+
+    // split fullText into lines
+    let lines = splitAndRemoveEmptyString(fullText, '\n');
+    
+    // find the starting index of each section
+    let sectionStartIndexes: number[] = [];
+    for (let sectionTitle of dependencySections) {
+        let newSectionIndex = lines.findIndex(text => text.includes(sectionTitle));
+        sectionStartIndexes.push(newSectionIndex);
+    }
+
+    // split lines into different sections
+    let sections: Array<string[]> = [];
+    for (let i = 0; i < sectionStartIndexes.length; i++) {
+        let nextSection: string[];
+
+        // startIndex of current section
+        let startIndex = sectionStartIndexes[i];
+                
+        // if current section is the last section
+        if ((i + 1) == sectionStartIndexes.length) {
+            nextSection = lines.slice(startIndex);
+        } else {
+            let endIndex = sectionStartIndexes[i + 1];
+            nextSection = lines.slice(startIndex, endIndex);
+        }
+
+        sections.push(nextSection);
+    }
+
+    return sections.map(parseIntoDependencySection);
+}
+
+function parseIntoDependencySection(section: string[]): DependencySection {
+    let dependencies: Array<string[]> = [];
+
+    let rows = section.slice(1);
+    for (const row of rows) {
+        let dependencyDetails = splitAndRemoveEmptyString(row, ' ');
+        if (dependencyDetails.length == 5) {
+            dependencies.push(dependencyDetails);
+        }
+    }
+
+    return dependencies.map(parseIntoPackageVersionInfo);
+}
+
+function parseIntoPackageVersionInfo(dependency: string[]): PackageVersionInfo {
+    return {
+        packageName: dependency[0],
+        currentVersion: dependency[1],
+        upgradableVersion: dependency[2],
+        resolvableVersion: dependency[3],
+        latestVersion: dependency[4]
+    };
+}
+
+function splitAndRemoveEmptyString(targetString: string, separator: string): string[] {
+    return targetString
+        .split(separator)
+        .filter(element => element != '');
+}
+
+interface PackageVersionInfo {
+    packageName: string,
+    currentVersion: string,
+    upgradableVersion: string,
+    resolvableVersion: string,
+    latestVersion: string
+}
+
+interface DependencySection {
+    [index: number]: PackageVersionInfo
+}
+
+interface Dependencies {
+    dependencies: DependencySection,
+    devDependencies: DependencySection,
+    transitiveDependencies: DependencySection,
+    transitiveDevDependencies: DependencySection
+}
+

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -17,7 +17,12 @@ export async function getOutdatedPackages(): Promise<OutdatedPackages> {
 
   await exec('flutter', ['pub', 'outdated'], options)
 
-  // TODO: error handling when error is emptyString
+  if (error.length > 0) {
+    throw Error(`
+    an error occured during the execution of flutter pub outdated.
+    error: ${error}
+    `)
+  }
 
   const outdatedPackages = parseIntoOutdatedPackages(output)
 

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,7 +1,5 @@
 import {exec, ExecOptions} from '@actions/exec'
 
-// TODO: add tests
-
 export async function outdatedPackages(): Promise<void> {
   let output = ''
   let error = ''
@@ -20,17 +18,13 @@ export async function outdatedPackages(): Promise<void> {
   await exec('flutter', ['pub', 'outdated'], options)
 
   // TODO: error handling when error is emptyString
-  // eslint-disable-next-line no-console
-  console.log(error)
 
   const dependencies = parseFlutterPubOutdatedOutput(output)
 
   // TODO: only returns dependencies and devDependencies
-  // eslint-disable-next-line no-console
-  console.log(dependencies)
 }
 
-function parseFlutterPubOutdatedOutput(
+export function parseFlutterPubOutdatedOutput(
   outputFromConsole: string
 ): Dependencies {
   const dependencySections = splitIntoDependencySections(outputFromConsole)
@@ -43,7 +37,9 @@ function parseFlutterPubOutdatedOutput(
   }
 }
 
-function splitIntoDependencySections(fullText: string): DependencySection[] {
+export function splitIntoDependencySections(
+  fullText: string
+): DependencySection[] {
   // title of each dependency section
   const dependencySections = [
     'Dependencies',
@@ -67,8 +63,8 @@ function splitIntoDependencySections(fullText: string): DependencySection[] {
   for (let i = 0; i < sectionStartIndexes.length; i++) {
     let nextSection: string[]
 
-    // startIndex of current section
-    const startIndex = sectionStartIndexes[i]
+    // startIndex of current section (excluding the section title)
+    const startIndex = sectionStartIndexes[i] + 1
 
     // if current section is the last section
     if (i + 1 === sectionStartIndexes.length) {
@@ -84,11 +80,12 @@ function splitIntoDependencySections(fullText: string): DependencySection[] {
   return sections.map(parseIntoDependencySection)
 }
 
-function parseIntoDependencySection(section: string[]): DependencySection {
+export function parseIntoDependencySection(
+  section: string[]
+): DependencySection {
   const dependencies: string[][] = []
 
-  const rows = section.slice(1)
-  for (const row of rows) {
+  for (const row of section) {
     const dependencyDetails = splitAndRemoveEmptyString(row, ' ')
     if (dependencyDetails.length === 5) {
       dependencies.push(dependencyDetails)
@@ -98,7 +95,9 @@ function parseIntoDependencySection(section: string[]): DependencySection {
   return dependencies.map(parseIntoPackageVersionInfo)
 }
 
-function parseIntoPackageVersionInfo(dependency: string[]): PackageVersionInfo {
+export function parseIntoPackageVersionInfo(
+  dependency: string[]
+): PackageVersionInfo {
   return {
     packageName: dependency[0],
     currentVersion: dependency[1],
@@ -108,14 +107,18 @@ function parseIntoPackageVersionInfo(dependency: string[]): PackageVersionInfo {
   }
 }
 
-function splitAndRemoveEmptyString(
+export function splitAndRemoveEmptyString(
   targetString: string,
   separator: string
 ): string[] {
   return targetString.split(separator).filter(element => element !== '')
 }
 
-interface PackageVersionInfo {
+//
+// Interface
+//
+
+export interface PackageVersionInfo {
   packageName: string
   currentVersion: string
   upgradableVersion: string
@@ -123,11 +126,11 @@ interface PackageVersionInfo {
   latestVersion: string
 }
 
-interface DependencySection {
+export interface DependencySection {
   [index: number]: PackageVersionInfo
 }
 
-interface Dependencies {
+export interface Dependencies {
   dependencies: DependencySection
   devDependencies: DependencySection
   transitiveDependencies: DependencySection

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,126 +1,135 @@
-import { exec, ExecOptions } from "@actions/exec";
+import {exec, ExecOptions} from '@actions/exec'
 
 // TODO: add tests
 
-export async function outdatedPackages() {
-    let output = '';
-    let error = '';
+export async function outdatedPackages(): Promise<void> {
+  let output = ''
+  let error = ''
 
-    const options: ExecOptions = {};
-    options.silent = true;
-    options.listeners = {
-        stdout: (data: Buffer) => {
-            output += data.toString();
-        },
-        stderr: (data: Buffer) => {
-            error += data.toString();
-        }
-    };
+  const options: ExecOptions = {}
+  options.silent = true
+  options.listeners = {
+    stdout: (data: Buffer) => {
+      output += data.toString()
+    },
+    stderr: (data: Buffer) => {
+      error += data.toString()
+    }
+  }
 
-    await exec('flutter', ['pub', 'outdated'], options);
+  await exec('flutter', ['pub', 'outdated'], options)
 
-    // TODO: error handling when error is emptyString
-    console.log(error);
+  // TODO: error handling when error is emptyString
+  // eslint-disable-next-line no-console
+  console.log(error)
 
-    let dependencies = parseFlutterPubOutdatedOutput(output);
+  const dependencies = parseFlutterPubOutdatedOutput(output)
 
-    // TODO: only returns dependencies and devDependencies
-    console.log(dependencies);
+  // TODO: only returns dependencies and devDependencies
+  // eslint-disable-next-line no-console
+  console.log(dependencies)
 }
 
-function parseFlutterPubOutdatedOutput(outputFromConsole: string): Dependencies {
-    let dependencySections = splitIntoDependencySections(outputFromConsole);
+function parseFlutterPubOutdatedOutput(
+  outputFromConsole: string
+): Dependencies {
+  const dependencySections = splitIntoDependencySections(outputFromConsole)
 
-    return {
-        dependencies: dependencySections[0],
-        devDependencies: dependencySections[1],
-        transitiveDependencies: dependencySections[2],
-        transitiveDevDependencies: dependencySections[3]
-    };
+  return {
+    dependencies: dependencySections[0],
+    devDependencies: dependencySections[1],
+    transitiveDependencies: dependencySections[2],
+    transitiveDevDependencies: dependencySections[3]
+  }
 }
 
 function splitIntoDependencySections(fullText: string): DependencySection[] {
-    // title of each dependency section
-    const dependencySections = ['Dependencies', 'dev_dependencies', 'transitive dependencies', 'transitive dev_dependencies'];
+  // title of each dependency section
+  const dependencySections = [
+    'Dependencies',
+    'dev_dependencies',
+    'transitive dependencies',
+    'transitive dev_dependencies'
+  ]
 
-    // split fullText into lines
-    let lines = splitAndRemoveEmptyString(fullText, '\n');
-    
-    // find the starting index of each section
-    let sectionStartIndexes: number[] = [];
-    for (let sectionTitle of dependencySections) {
-        let newSectionIndex = lines.findIndex(text => text.includes(sectionTitle));
-        sectionStartIndexes.push(newSectionIndex);
+  // split fullText into lines
+  const lines = splitAndRemoveEmptyString(fullText, '\n')
+
+  // find the starting index of each section
+  const sectionStartIndexes: number[] = []
+  for (const sectionTitle of dependencySections) {
+    const newSectionIndex = lines.findIndex(text => text.includes(sectionTitle))
+    sectionStartIndexes.push(newSectionIndex)
+  }
+
+  // split lines into different sections
+  const sections: string[][] = []
+  for (let i = 0; i < sectionStartIndexes.length; i++) {
+    let nextSection: string[]
+
+    // startIndex of current section
+    const startIndex = sectionStartIndexes[i]
+
+    // if current section is the last section
+    if (i + 1 === sectionStartIndexes.length) {
+      nextSection = lines.slice(startIndex)
+    } else {
+      const endIndex = sectionStartIndexes[i + 1]
+      nextSection = lines.slice(startIndex, endIndex)
     }
 
-    // split lines into different sections
-    let sections: Array<string[]> = [];
-    for (let i = 0; i < sectionStartIndexes.length; i++) {
-        let nextSection: string[];
+    sections.push(nextSection)
+  }
 
-        // startIndex of current section
-        let startIndex = sectionStartIndexes[i];
-                
-        // if current section is the last section
-        if ((i + 1) == sectionStartIndexes.length) {
-            nextSection = lines.slice(startIndex);
-        } else {
-            let endIndex = sectionStartIndexes[i + 1];
-            nextSection = lines.slice(startIndex, endIndex);
-        }
-
-        sections.push(nextSection);
-    }
-
-    return sections.map(parseIntoDependencySection);
+  return sections.map(parseIntoDependencySection)
 }
 
 function parseIntoDependencySection(section: string[]): DependencySection {
-    let dependencies: Array<string[]> = [];
+  const dependencies: string[][] = []
 
-    let rows = section.slice(1);
-    for (const row of rows) {
-        let dependencyDetails = splitAndRemoveEmptyString(row, ' ');
-        if (dependencyDetails.length == 5) {
-            dependencies.push(dependencyDetails);
-        }
+  const rows = section.slice(1)
+  for (const row of rows) {
+    const dependencyDetails = splitAndRemoveEmptyString(row, ' ')
+    if (dependencyDetails.length === 5) {
+      dependencies.push(dependencyDetails)
     }
+  }
 
-    return dependencies.map(parseIntoPackageVersionInfo);
+  return dependencies.map(parseIntoPackageVersionInfo)
 }
 
 function parseIntoPackageVersionInfo(dependency: string[]): PackageVersionInfo {
-    return {
-        packageName: dependency[0],
-        currentVersion: dependency[1],
-        upgradableVersion: dependency[2],
-        resolvableVersion: dependency[3],
-        latestVersion: dependency[4]
-    };
+  return {
+    packageName: dependency[0],
+    currentVersion: dependency[1],
+    upgradableVersion: dependency[2],
+    resolvableVersion: dependency[3],
+    latestVersion: dependency[4]
+  }
 }
 
-function splitAndRemoveEmptyString(targetString: string, separator: string): string[] {
-    return targetString
-        .split(separator)
-        .filter(element => element != '');
+function splitAndRemoveEmptyString(
+  targetString: string,
+  separator: string
+): string[] {
+  return targetString.split(separator).filter(element => element !== '')
 }
 
 interface PackageVersionInfo {
-    packageName: string,
-    currentVersion: string,
-    upgradableVersion: string,
-    resolvableVersion: string,
-    latestVersion: string
+  packageName: string
+  currentVersion: string
+  upgradableVersion: string
+  resolvableVersion: string
+  latestVersion: string
 }
 
 interface DependencySection {
-    [index: number]: PackageVersionInfo
+  [index: number]: PackageVersionInfo
 }
 
 interface Dependencies {
-    dependencies: DependencySection,
-    devDependencies: DependencySection,
-    transitiveDependencies: DependencySection,
-    transitiveDevDependencies: DependencySection
+  dependencies: DependencySection
+  devDependencies: DependencySection
+  transitiveDependencies: DependencySection
+  transitiveDevDependencies: DependencySection
 }
-

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,6 +1,6 @@
 import {exec, ExecOptions} from '@actions/exec'
 
-export async function outdatedPackages(): Promise<void> {
+export async function outdatedPackages(): Promise<Dependencies> {
   let output = ''
   let error = ''
 
@@ -21,7 +21,10 @@ export async function outdatedPackages(): Promise<void> {
 
   const dependencies = parseFlutterPubOutdatedOutput(output)
 
-  // TODO: only returns dependencies and devDependencies
+  return {
+    dependencies: dependencies.dependencies,
+    devDependencies: dependencies.devDependencies
+  }
 }
 
 export function parseFlutterPubOutdatedOutput(
@@ -133,6 +136,6 @@ export interface DependencySection {
 export interface Dependencies {
   dependencies: DependencySection
   devDependencies: DependencySection
-  transitiveDependencies: DependencySection
-  transitiveDevDependencies: DependencySection
+  transitiveDependencies?: DependencySection
+  transitiveDevDependencies?: DependencySection
 }

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,6 +1,6 @@
 import {exec, ExecOptions} from '@actions/exec'
 
-export async function outdatedPackages(): Promise<Dependencies> {
+export async function getOutdatedPackages(): Promise<OutdatedPackages> {
   let output = ''
   let error = ''
 
@@ -19,17 +19,17 @@ export async function outdatedPackages(): Promise<Dependencies> {
 
   // TODO: error handling when error is emptyString
 
-  const dependencies = parseFlutterPubOutdatedOutput(output)
+  const outdatedPackages = parseIntoOutdatedPackages(output)
 
   return {
-    dependencies: dependencies.dependencies,
-    devDependencies: dependencies.devDependencies
+    dependencies: outdatedPackages.dependencies,
+    devDependencies: outdatedPackages.devDependencies
   }
 }
 
-export function parseFlutterPubOutdatedOutput(
+export function parseIntoOutdatedPackages(
   outputFromConsole: string
-): Dependencies {
+): OutdatedPackages {
   const dependencySections = splitIntoDependencySections(outputFromConsole)
 
   return {
@@ -133,7 +133,7 @@ export interface DependencySection {
   [index: number]: PackageVersionInfo
 }
 
-export interface Dependencies {
+export interface OutdatedPackages {
   dependencies: DependencySection
   devDependencies: DependencySection
   transitiveDependencies?: DependencySection

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,4 +9,5 @@
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
   "exclude": ["node_modules", "**/*.test.ts"]
+//   "exclude": ["node_modules"]                 /* Uncomment to allow eslint in test files too. Comment out when performing build. */
 }


### PR DESCRIPTION
## Summary
A module containing functions to extract packages that need to be upgraded from `$ flutter pub outdated`

## Details
- add [@actions/exec](https://github.com/actions/toolkit/blob/main/packages/exec) to enable execution of cli commands e6d1e6f
- implemented `outdated.ts` module
<details>
<summary><code>outdated.ts</code></summary>

### Interfaces
An example output from the execution of `$ flutter pub outdated`. ([Source](https://dart.dev/tools/pub/cmd/pub-outdated#example))
There are 4 main types of dependencies, which are `Dependencies`, `dev_dependencies`, `transitive dependencies`, `transitive dev_dependencies`.
The last section of this output (after 4 sections about dependencies) has recommendations on how to upgrade each packages.

```zsh
Dependencies  Current    Upgradable  Resolvable  Latest  
args          1.4.4      1.6.0       1.6.0       1.6.0   
http          0.11.3+17  0.11.3+17   0.12.1      0.12.1  
path          1.6.2      1.6.2       1.6.2       1.7.0   

dev_dependencies: all up-to-date

transitive dependencies
meta          1.1.6      1.1.6       1.1.6       1.1.8   

transitive dev_dependencies: all up-to-date

1 upgradable dependency is locked (in pubspec.lock) to an older version.
To update it, use `dart pub upgrade`.

1 dependency is constrained to a version that is older than a resolvable version.
To update it, edit pubspec.yaml.
```
We can fit this output into the following structure. (ignoring the recommendations)
```
+ OutdatedPackages
| + Dependencies
  | + args
    | - Current
    | - Upgradable
    | - Resolvable
    | - Latest
  | + path
    | - Current
    | - Upgradable
    | - Resolvable
    | - Latest
  | + http
    | - Current
    | - Upgradable
    | - Resolvable
    | - Latest
| + dev_dependencies
| + transitive dependencies
  | + meta
    | - Current
    | - Upgradable
    | - Resolvable
    | - Latest
| + transitive dev_dependencies
```
Grouping up similar parts of the structure and we will have the following interfaces to represent the structure above
```ts
/*
+ OutdatedPackages
| + DependencySection
  | + PackageVersionInfo
  | + PackageVersionInfo
  | + PackageVersionInfo
  | + PackageVersionInfo
| + DependencySection
| + DependencySection
  | + PackageVersionInfo
| + DependencySection
*/

interface PackageVersionInfo {
  packageName: string
  currentVersion: string
  upgradableVersion: string
  resolvableVersion: string
  latestVersion: string
}

interface DependencySection {
  [index: number]: PackageVersionInfo
}

// transitive_dependencies are usually updated when their 'parent' dependencies are updated,
// so transitiveDependencies and transtiveDevDependencies are made optional.
interface OutdatedPackages {
  dependencies: DependencySection
  devDependencies: DependencySection
  transitiveDependencies?: DependencySection
  transitiveDevDependencies?: DependencySection
}
```

### Functions
#### `parseIntoPackageVersionInfo()`
This function will turn an array consisting of 5 strings into `PackageVersionInfo`.
```ts
/*
For example, 
['args', '1.4.4', '1.6.0', '1.6.0', '1.6.0'] will be turned into the following.
*/ 
{
  packageName: 'args',
  currentVersion: '1.4.4',
  upgradableVersion: '1.6.0',
  resolvableVersion: '1.6.0',
  latestVersion: '1.6.0'
}
```

#### `parseIntoDependencySection()`
This function will turn an array of strings into `DependencySection`.
※ when an element (string) in this array is split on `' '` and forms an array of string without 5 elements, that element will not be turn into `PackageVersionInfo` and will not be included in `DependencySection`. One example of this kind of elements is the recommendations at the end of the cli output. (i.e. `1 dependency is constrained to a version that is older than a resolvable version.`)
```ts
/*
For example,
[
  'args          1.4.4      1.6.0       1.6.0       1.6.0   '
  'http          0.11.3+17  0.11.3+17   0.12.1      0.12.1  '
  'path          1.6.2      1.6.2       1.6.2       1.7.0   '
]
will be converted into the following.
*/
[
  { /* PackageVersionInfo of args */ },
  { /* PackageVersionInfo of http */ },
  { /* PackageVersionInfo of path */ },
]
```
#### `splitIntoDependencySections()`
This function will split the cli output into 4 different `DependencySection`.
Since the 'title' for each section is fixed, we will use that as a reference to split the output into 4 long strings.
```ts
  // title of each dependency section
  const dependencySections = [
    'Dependencies',
    'dev_dependencies',
    'transitive dependencies',
    'transitive dev_dependencies'
  ]
```
Rows between 2 section titles are put into one array and are passed to `parseIntoDependencySection()`.
When we have the example output from [here](https://dart.dev/tools/pub/cmd/pub-outdated#example), the following object will be returned from `splitIntoDependencySections()`
```ts
[
  // Dependencies
  [
    { /* PackageVersionInfo of args */ },
    { /* PackageVersionInfo of http */ },
    { /* PackageVersionInfo of path */ },
  ],
  // dev_dependencies
  [ ],
  // transitive dependencies
  [
    { /* PackageVersionInfo of meta */ },
  ],
  // transitive dev_dependencies
  [ ],
]
```

#### `parseIntoOutdatedPackages()`
This function will take the return value from `splitIntoDependencySections()` and turn it into `OutdatedPackages`
```ts
{
  dependencies: [ /* DependencySection of Dependencies */ ],
  devDependencies: [ /* DependencySection of dev_dependencies */ ],
  transitiveDependencies: [ /* DependencySection of transitive dependencies */ ],
  transitiveDevDependencies: [ /* DependencySection of transitive dev_dependencies */ ]
}
```
</details>

## Others
### Reference
- [@actions/exec](https://github.com/actions/toolkit/tree/main/packages/exec)
- [TypeScript Interface](https://www.typescriptlang.org/docs/handbook/interfaces.html)
- [TypeScript Playground](https://www.typescriptlang.org/play)
  - allow faster debug than local development (with minimum setup)