### PR TITLE
`pubspec.yaml` Reader

### DIFF
--- a/__tests__/outdated.test.ts
+++ b/__tests__/outdated.test.ts
@@ -1,4 +1,5 @@
 import * as outdated from '../src/outdated'
+import * as interfaces from '../src/interfaces'
 
 describe('splitAndRemoveEmptyString', () => {
   it('split a long string into string[] and remove empty string', () => {
@@ -26,7 +27,7 @@ describe('parseIntoPackageVersionInfo', () => {
   it('convert an array of string (length of 5) into PackageVersionInfo', () => {
     const arrayOfString = ['Donec', 'nec', 'libero', 'et', 'lorem']
     const result = outdated.parseIntoPackageVersionInfo(arrayOfString)
-    const expectedResult: outdated.PackageVersionInfo = {
+    const expectedResult: interfaces.PackageVersionInfo = {
       packageName: 'Donec',
       currentVersion: 'nec',
       upgradableVersion: 'libero',
@@ -46,7 +47,7 @@ describe('parseIntoDependencySection', () => {
       'Nullam ac dolor ac sapien'
     ]
     const result = outdated.parseIntoDependencySection(arrayOfString)
-    const expectedResult: outdated.DependencySection = [
+    const expectedResult: interfaces.DependencySection = [
       {
         packageName: 'Phasellus',
         currentVersion: 'vel',
@@ -81,7 +82,7 @@ describe('splitIntoDependencySections', () => {
       Mauris sed nulla et risus placerat blandit vel non turpis
     `
     const result = outdated.splitIntoDependencySections(multiLineString)
-    const expectedResult: outdated.DependencySection[] = [
+    const expectedResult: interfaces.DependencySection[] = [
       [
         {
           packageName: 'Cras',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.15",
+        "@types/js-yaml": "^4.0.0",
         "@types/node": "^14.14.9",
         "@typescript-eslint/parser": "^4.8.1",
         "@vercel/ncc": "^0.25.1",
@@ -1585,6 +1586,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.3",
@@ -11929,6 +11936,12 @@
           }
         }
       }
+    },
+    "@types/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
+    "@types/js-yaml": "^4.0.0",
     "@types/node": "^14.14.9",
     "@typescript-eslint/parser": "^4.8.1",
     "@vercel/ncc": "^0.25.1",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,41 @@
+export interface PackageVersionInfo {
+  packageName: string
+  currentVersion: string
+  upgradableVersion?: string
+  resolvableVersion?: string
+  latestVersion?: string
+}
+
+export interface DependencySection {
+  [index: number]: PackageVersionInfo
+}
+
+export interface Packages {
+  dependencies: DependencySection
+  devDependencies: DependencySection
+  transitiveDependencies?: DependencySection
+  transitiveDevDependencies?: DependencySection
+}
+
+// https://dart.dev/tools/pub/pubspec
+export interface Pubspec {
+  name: string
+  version: string
+  description: string
+  homepage?: string
+  repository?: string
+  issue_tracker?: string
+  documentation?: string
+  dependencies: object
+  dev_dependencies: object
+  dependency_overrides?: object
+  environment: FlutterSdk
+  executables?: object
+  publish_to?: string
+  flutter: object
+  flutter_localizations?: FlutterSdk
+}
+
+interface FlutterSdk {
+  sdk: string
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,13 @@
 import * as core from '@actions/core'
 import {getOutdatedPackages} from './outdated'
+import {getCurrentPackages} from './pubspecReader'
 
 async function run(): Promise<void> {
   try {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const outdatedPackages = await getOutdatedPackages()
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const currentPackages = getCurrentPackages()
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,4 +1,5 @@
 import {exec, ExecOptions} from '@actions/exec'
+import {DependencySection, Packages, PackageVersionInfo} from './interfaces'
 
 export async function getOutdatedPackages(): Promise<Packages> {
   let output = ''
@@ -118,27 +119,4 @@ export function splitAndRemoveEmptyString(
   separator: string
 ): string[] {
   return targetString.split(separator).filter(element => element !== '')
-}
-
-//
-// Interface
-//
-
-export interface PackageVersionInfo {
-  packageName: string
-  currentVersion: string
-  upgradableVersion?: string
-  resolvableVersion?: string
-  latestVersion?: string
-}
-
-export interface DependencySection {
-  [index: number]: PackageVersionInfo
-}
-
-export interface Packages {
-  dependencies: DependencySection
-  devDependencies: DependencySection
-  transitiveDependencies?: DependencySection
-  transitiveDevDependencies?: DependencySection
 }

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,6 +1,6 @@
 import {exec, ExecOptions} from '@actions/exec'
 
-export async function getOutdatedPackages(): Promise<OutdatedPackages> {
+export async function getOutdatedPackages(): Promise<Packages> {
   let output = ''
   let error = ''
 
@@ -32,9 +32,7 @@ export async function getOutdatedPackages(): Promise<OutdatedPackages> {
   }
 }
 
-export function parseIntoOutdatedPackages(
-  outputFromConsole: string
-): OutdatedPackages {
+export function parseIntoOutdatedPackages(outputFromConsole: string): Packages {
   const dependencySections = splitIntoDependencySections(outputFromConsole)
 
   return {
@@ -129,16 +127,16 @@ export function splitAndRemoveEmptyString(
 export interface PackageVersionInfo {
   packageName: string
   currentVersion: string
-  upgradableVersion: string
-  resolvableVersion: string
-  latestVersion: string
+  upgradableVersion?: string
+  resolvableVersion?: string
+  latestVersion?: string
 }
 
 export interface DependencySection {
   [index: number]: PackageVersionInfo
 }
 
-export interface OutdatedPackages {
+export interface Packages {
   dependencies: DependencySection
   devDependencies: DependencySection
   transitiveDependencies?: DependencySection

--- a/src/pubspecReader.ts
+++ b/src/pubspecReader.ts
@@ -1,0 +1,74 @@
+import {assert} from 'console'
+import * as fs from 'fs'
+import * as yaml from 'js-yaml'
+import {DependencySection, Packages, PackageVersionInfo} from './outdated'
+
+export function getCurrentPackages(): Packages {
+  const pathToPubSpec = './pubspec.yaml'
+
+  const pubspec = readYaml(pathToPubSpec)
+
+  const dependencies = parseIntoDependencySection(pubspec.dependencies)
+  const devDependencies = parseIntoDependencySection(pubspec.dev_dependencies)
+
+  return {
+    dependencies,
+    devDependencies
+  }
+}
+
+function parseIntoDependencySection(dependencies: object): DependencySection {
+  const packageNameToSkip = ['flutter', 'footer', 'flutter_test']
+
+  const dependencySection = []
+
+  for (const [packageName, currentVersion] of Object.entries(dependencies)) {
+    if (!packageNameToSkip.includes(packageName)) {
+      const dependency: PackageVersionInfo = {
+        packageName,
+        currentVersion
+      }
+      dependencySection.push(dependency)
+    }
+  }
+
+  return dependencySection
+}
+
+export function readYaml(pathToYamlFile: string): Pubspec {
+  let doc
+
+  try {
+    doc = yaml.load(fs.readFileSync(pathToYamlFile, 'utf-8')) as Pubspec
+  } catch (error) {
+    throw Error(`
+    an error occured during loading of yaml file.
+    error: ${error}
+    `)
+  }
+
+  return doc
+}
+
+// https://dart.dev/tools/pub/pubspec
+interface Pubspec {
+  name: string
+  version: string
+  description: string
+  homepage?: string
+  repository?: string
+  issue_tracker?: string
+  documentation?: string
+  dependencies: object
+  dev_dependencies: object
+  dependency_overrides?: object
+  environment: FlutterSdk
+  executables?: object
+  publish_to?: string
+  flutter: object
+  flutter_localizations?: FlutterSdk
+}
+
+interface FlutterSdk {
+  sdk: string
+}

--- a/src/pubspecReader.ts
+++ b/src/pubspecReader.ts
@@ -1,7 +1,11 @@
-import {assert} from 'console'
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
-import {DependencySection, Packages, PackageVersionInfo} from './outdated'
+import {
+  DependencySection,
+  Packages,
+  PackageVersionInfo,
+  Pubspec
+} from './interfaces'
 
 export function getCurrentPackages(): Packages {
   const pathToPubSpec = './pubspec.yaml'
@@ -48,27 +52,4 @@ export function readYaml(pathToYamlFile: string): Pubspec {
   }
 
   return doc
-}
-
-// https://dart.dev/tools/pub/pubspec
-interface Pubspec {
-  name: string
-  version: string
-  description: string
-  homepage?: string
-  repository?: string
-  issue_tracker?: string
-  documentation?: string
-  dependencies: object
-  dev_dependencies: object
-  dependency_overrides?: object
-  environment: FlutterSdk
-  executables?: object
-  publish_to?: string
-  flutter: object
-  flutter_localizations?: FlutterSdk
-}
-
-interface FlutterSdk {
-  sdk: string
 }


### PR DESCRIPTION
## Summary
Implemented a few functions in `pubspecReader.ts` to handle reading and parsing of `pubspec.yaml` and extract package information in `dependencies` and `dev_dependencies` section of the pubspec file.

## Details
- moved definitions of interfaces into a separate file `interfaces.ts` 4c61d02
- add `pubspecReader.ts` to handle reading and parsing of `pubspec.yaml`

<details>
<summary><code>pubspecReader.ts</code></summary>

### Reading YAML file: `readYaml()`
Use [js-yaml](https://github.com/nodeca/js-yaml) to read the content of `pubspec.yaml` (it will be changed into an object).
※ a `Pubspec` interface is defined in `interface.ts` to represent the structure of `pubspec.yaml` after read. The current definition of this interface is likely to be inaccurate as it's not created with enough samples of `pubspec.yaml`.

### Changing `Pubspec` into `DependencySection`: `parseIntoDependencySection()`
A normal pubspec file will not contain flutter related information, but a pubspec file in a Flutter project does.
Usually, these Flutter-related information contains the sdk's version, which its's not important during the extraction of packages' version info from pubspec file. So it will be skip during parsing.

</details>

## Others
### Helpful Tools
- [JSONFormatter](https://jsonformatter.curiousconcept.com/#)
- [json2ts](http://json2ts.com/)