### PR TITLE
Pubspec Updater

### DIFF
--- a/__tests__/outdated.test.ts
+++ b/__tests__/outdated.test.ts
@@ -46,8 +46,8 @@ describe('parseIntoDependencySection', () => {
       'Nulla id dui malesuada lacus porttitor pulvinar',
       'Nullam ac dolor ac sapien'
     ]
-    const result = outdated.parseIntoDependencySection(arrayOfString)
-    const expectedResult: interfaces.DependencySection = [
+    const result = outdated.parseIntoArrayOfPackageVersionInfo(arrayOfString)
+    const expectedResult: interfaces.PackageVersionInfo[] = [
       {
         packageName: 'Phasellus',
         currentVersion: 'vel',
@@ -82,7 +82,7 @@ describe('splitIntoDependencySections', () => {
       Mauris sed nulla et risus placerat blandit vel non turpis
     `
     const result = outdated.splitIntoDependencySections(multiLineString)
-    const expectedResult: interfaces.DependencySection[] = [
+    const expectedResult: interfaces.PackageVersionInfo[][] = [
       [
         {
           packageName: 'Cras',

--- a/__tests__/pubspecUpdater.test.ts
+++ b/__tests__/pubspecUpdater.test.ts
@@ -127,7 +127,7 @@ describe('udpatePubspecDependencies', () => {
   ]
 
   it('updates upgradable dependencies', () => {
-    const result = updater.udpatePubspecDependencies(pubspec, dependencies)
+    const result = updater.updatePubspecDependencies(pubspec, dependencies)
     const expectedResult = {
       name: 'test',
       version: '0.0.0',

--- a/__tests__/pubspecUpdater.test.ts
+++ b/__tests__/pubspecUpdater.test.ts
@@ -1,4 +1,4 @@
-import {Pubspec} from '../src/interfaces'
+import {PackageVersionInfo, Pubspec} from '../src/interfaces'
 import * as updater from '../src/pubspecUpdater'
 
 describe('updatePackageToResolvableVersion', () => {
@@ -89,5 +89,65 @@ describe('updatePackageToResolvableVersion', () => {
 
       expect(result).toEqual(expectedResult)
     })
+  })
+})
+
+describe('udpatePubspecDependencies', () => {
+  const pubspec = {
+    name: 'test',
+    version: '0.0.0',
+    description: 'pubspec for testing',
+    environment: {sdk: '>=2.7.0 <3.0.0'},
+    dependencies: {
+      flutter: {sdk: 'flutter'},
+      cupertino_icons: '^1.0.0',
+      provider: '4.3.2+3'
+    },
+    dev_dependencies: {
+      effective_dart: '^1.3.0',
+      flutter_test: {sdk: 'flutter'}
+    },
+    flutter: {
+      'uses-material-design': true,
+      assets: []
+    }
+  }
+
+  const dependencies: PackageVersionInfo[] = [
+    {
+      packageName: 'cupertino_icons',
+      currentVersion: '1.0.0',
+      resolvableVersion: '2.0.0'
+    },
+    {
+      packageName: 'provider',
+      currentVersion: '4.3.2+3',
+      resolvableVersion: '5.0.0'
+    }
+  ]
+
+  it('updates upgradable dependencies', () => {
+    const result = updater.udpatePubspecDependencies(pubspec, dependencies)
+    const expectedResult = {
+      name: 'test',
+      version: '0.0.0',
+      description: 'pubspec for testing',
+      environment: {sdk: '>=2.7.0 <3.0.0'},
+      dependencies: {
+        flutter: {sdk: 'flutter'},
+        cupertino_icons: '^2.0.0',
+        provider: '^5.0.0'
+      },
+      dev_dependencies: {
+        effective_dart: '^1.3.0',
+        flutter_test: {sdk: 'flutter'}
+      },
+      flutter: {
+        'uses-material-design': true,
+        assets: []
+      }
+    }
+
+    expect(result).toStrictEqual(expectedResult)
   })
 })

--- a/__tests__/pubspecUpdater.test.ts
+++ b/__tests__/pubspecUpdater.test.ts
@@ -151,3 +151,58 @@ describe('udpatePubspecDependencies', () => {
     expect(result).toStrictEqual(expectedResult)
   })
 })
+
+describe('udpatePubspecDevDependencies', () => {
+  const pubspec = {
+    name: 'test',
+    version: '0.0.0',
+    description: 'pubspec for testing',
+    environment: {sdk: '>=2.7.0 <3.0.0'},
+    dependencies: {
+      flutter: {sdk: 'flutter'},
+      cupertino_icons: '^1.0.0',
+      provider: '4.3.2+3'
+    },
+    dev_dependencies: {
+      effective_dart: '^1.3.0',
+      flutter_test: {sdk: 'flutter'}
+    },
+    flutter: {
+      'uses-material-design': true,
+      assets: []
+    }
+  }
+
+  const dependencies: PackageVersionInfo[] = [
+    {
+      packageName: 'effective_dart',
+      currentVersion: '1.3.0',
+      resolvableVersion: '2.0.0'
+    }
+  ]
+
+  it('updates upgradable dependencies', () => {
+    const result = updater.updatePubspecDevDependencies(pubspec, dependencies)
+    const expectedResult = {
+      name: 'test',
+      version: '0.0.0',
+      description: 'pubspec for testing',
+      environment: {sdk: '>=2.7.0 <3.0.0'},
+      dependencies: {
+        flutter: {sdk: 'flutter'},
+        cupertino_icons: '^1.0.0',
+        provider: '4.3.2+3'
+      },
+      dev_dependencies: {
+        effective_dart: '^2.0.0',
+        flutter_test: {sdk: 'flutter'}
+      },
+      flutter: {
+        'uses-material-design': true,
+        assets: []
+      }
+    }
+
+    expect(result).toStrictEqual(expectedResult)
+  })
+})

--- a/__tests__/pubspecUpdater.test.ts
+++ b/__tests__/pubspecUpdater.test.ts
@@ -1,8 +1,8 @@
-import {PackageVersionInfo, Pubspec} from '../src/interfaces'
+import * as interfaces from '../src/interfaces'
 import * as updater from '../src/pubspecUpdater'
 
 describe('updatePackageToResolvableVersion', () => {
-  let pubspec: Pubspec
+  let pubspec: interfaces.Pubspec
 
   beforeEach(() => {
     pubspec = {
@@ -113,7 +113,7 @@ describe('udpatePubspecDependencies', () => {
     }
   }
 
-  const dependencies: PackageVersionInfo[] = [
+  const dependencies: interfaces.PackageVersionInfo[] = [
     {
       packageName: 'cupertino_icons',
       currentVersion: '1.0.0',
@@ -173,7 +173,7 @@ describe('udpatePubspecDevDependencies', () => {
     }
   }
 
-  const dependencies: PackageVersionInfo[] = [
+  const dependencies: interfaces.PackageVersionInfo[] = [
     {
       packageName: 'effective_dart',
       currentVersion: '1.3.0',
@@ -192,6 +192,79 @@ describe('udpatePubspecDevDependencies', () => {
         flutter: {sdk: 'flutter'},
         cupertino_icons: '^1.0.0',
         provider: '4.3.2+3'
+      },
+      dev_dependencies: {
+        effective_dart: '^2.0.0',
+        flutter_test: {sdk: 'flutter'}
+      },
+      flutter: {
+        'uses-material-design': true,
+        assets: []
+      }
+    }
+
+    expect(result).toStrictEqual(expectedResult)
+  })
+})
+
+describe('updatePubspecToResolvableVersion', () => {
+  const pubspec = {
+    name: 'test',
+    version: '0.0.0',
+    description: 'pubspec for testing',
+    environment: {sdk: '>=2.7.0 <3.0.0'},
+    dependencies: {
+      flutter: {sdk: 'flutter'},
+      cupertino_icons: '^1.0.0',
+      provider: '4.3.2+3'
+    },
+    dev_dependencies: {
+      effective_dart: '^1.3.0',
+      flutter_test: {sdk: 'flutter'}
+    },
+    flutter: {
+      'uses-material-design': true,
+      assets: []
+    }
+  }
+  const dependencies: interfaces.PackageVersionInfo[] = [
+    {
+      packageName: 'cupertino_icons',
+      currentVersion: '1.0.0',
+      resolvableVersion: '2.0.0'
+    },
+    {
+      packageName: 'provider',
+      currentVersion: '4.3.2+3',
+      resolvableVersion: '5.0.0'
+    }
+  ]
+  const devDependencies: interfaces.PackageVersionInfo[] = [
+    {
+      packageName: 'effective_dart',
+      currentVersion: '1.3.0',
+      resolvableVersion: '2.0.0'
+    }
+  ]
+  const outdatedPackages: interfaces.Packages = {
+    dependencies,
+    devDependencies
+  }
+
+  it('updates both dependencies and devDependencies', () => {
+    const result = updater.updatePubspecToResolvableVersion(
+      pubspec,
+      outdatedPackages
+    )
+    const expectedResult = {
+      name: 'test',
+      version: '0.0.0',
+      description: 'pubspec for testing',
+      environment: {sdk: '>=2.7.0 <3.0.0'},
+      dependencies: {
+        flutter: {sdk: 'flutter'},
+        cupertino_icons: '^2.0.0',
+        provider: '^5.0.0'
       },
       dev_dependencies: {
         effective_dart: '^2.0.0',

--- a/__tests__/pubspecUpdater.test.ts
+++ b/__tests__/pubspecUpdater.test.ts
@@ -1,0 +1,93 @@
+import {Pubspec} from '../src/interfaces'
+import * as updater from '../src/pubspecUpdater'
+
+describe('updatePackageToResolvableVersion', () => {
+  let pubspec: Pubspec
+
+  beforeEach(() => {
+    pubspec = {
+      name: 'test',
+      version: '0.0.0',
+      description: 'pubspec for testing',
+      environment: {sdk: '>=2.7.0 <3.0.0'},
+      dependencies: {
+        flutter: {sdk: 'flutter'},
+        cupertino_icons: '^1.0.0',
+        provider: '4.3.2+3'
+      },
+      dev_dependencies: {
+        effective_dart: '^1.3.0',
+        flutter_test: {sdk: 'flutter'}
+      },
+      flutter: {
+        'uses-material-design': true,
+        assets: []
+      }
+    }
+  })
+
+  describe('dependencies', () => {
+    it('updates cupertino_icons to ^2.0.0', () => {
+      const result = updater.updatePackageToResolvableVersion(
+        pubspec,
+        'cupertino_icons',
+        '2.0.0'
+      )
+
+      const expectedResult = {
+        name: 'test',
+        version: '0.0.0',
+        description: 'pubspec for testing',
+        environment: {sdk: '>=2.7.0 <3.0.0'},
+        dependencies: {
+          flutter: {sdk: 'flutter'},
+          cupertino_icons: '^2.0.0',
+          provider: '4.3.2+3'
+        },
+        dev_dependencies: {
+          effective_dart: '^1.3.0',
+          flutter_test: {sdk: 'flutter'}
+        },
+        flutter: {
+          'uses-material-design': true,
+          assets: []
+        }
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+
+  describe('devDependencies', () => {
+    it('updates effective_dart to ^2.0.0', () => {
+      const result = updater.updatePackageToResolvableVersion(
+        pubspec,
+        'effective_dart',
+        '2.0.0',
+        true
+      )
+
+      const expectedResult = {
+        name: 'test',
+        version: '0.0.0',
+        description: 'pubspec for testing',
+        environment: {sdk: '>=2.7.0 <3.0.0'},
+        dependencies: {
+          flutter: {sdk: 'flutter'},
+          cupertino_icons: '^1.0.0',
+          provider: '4.3.2+3'
+        },
+        dev_dependencies: {
+          effective_dart: '^2.0.0',
+          flutter_test: {sdk: 'flutter'}
+        },
+        flutter: {
+          'uses-material-design': true,
+          assets: []
+        }
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+})

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,14 +26,18 @@ export interface Pubspec {
   repository?: string
   issue_tracker?: string
   documentation?: string
-  dependencies: object
-  dev_dependencies: object
+  dependencies: PubspecDependencies
+  dev_dependencies: PubspecDependencies
   dependency_overrides?: object
   environment: FlutterSdk
   executables?: object
   publish_to?: string
   flutter: object
   flutter_localizations?: FlutterSdk
+}
+
+interface PubspecDependencies {
+  [index: string]: string | FlutterSdk | null
 }
 
 interface FlutterSdk {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,15 +6,11 @@ export interface PackageVersionInfo {
   latestVersion?: string
 }
 
-export interface DependencySection {
-  [index: number]: PackageVersionInfo
-}
-
 export interface Packages {
-  dependencies: DependencySection
-  devDependencies: DependencySection
-  transitiveDependencies?: DependencySection
-  transitiveDevDependencies?: DependencySection
+  dependencies: PackageVersionInfo[]
+  devDependencies: PackageVersionInfo[]
+  transitiveDependencies?: PackageVersionInfo[]
+  transitiveDevDependencies?: PackageVersionInfo[]
 }
 
 // https://dart.dev/tools/pub/pubspec

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,24 @@
 import * as core from '@actions/core'
 import {getOutdatedPackages} from './outdated'
-import {getCurrentPackages} from './pubspecReader'
+import {getCurrentPackages, readPubspec} from './pubspecReader'
+import {updatePubspecToResolvableVersion} from './pubspecUpdater'
 
 async function run(): Promise<void> {
   try {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const outdatedPackages = await getOutdatedPackages()
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const currentPackages = getCurrentPackages()
+
+    // read pubspec.yaml
+    const pubspec = readPubspec()
+    // get outdated package
+    const outdatedPackages = await getOutdatedPackages()
+    // update pubspec
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const updatedPubspec = updatePubspecToResolvableVersion(
+      pubspec,
+      outdatedPackages
+    )
+    // TODO: write to pubspec
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,5 +1,5 @@
 import {exec, ExecOptions} from '@actions/exec'
-import {DependencySection, Packages, PackageVersionInfo} from './interfaces'
+import {Packages, PackageVersionInfo} from './interfaces'
 
 export async function getOutdatedPackages(): Promise<Packages> {
   let output = ''
@@ -46,7 +46,7 @@ export function parseIntoOutdatedPackages(outputFromConsole: string): Packages {
 
 export function splitIntoDependencySections(
   fullText: string
-): DependencySection[] {
+): PackageVersionInfo[][] {
   // title of each dependency section
   const dependencySections = [
     'Dependencies',
@@ -84,12 +84,12 @@ export function splitIntoDependencySections(
     sections.push(nextSection)
   }
 
-  return sections.map(parseIntoDependencySection)
+  return sections.map(parseIntoArrayOfPackageVersionInfo)
 }
 
-export function parseIntoDependencySection(
+export function parseIntoArrayOfPackageVersionInfo(
   section: string[]
-): DependencySection {
+): PackageVersionInfo[] {
   const dependencies: string[][] = []
 
   for (const row of section) {

--- a/src/pubspecReader.ts
+++ b/src/pubspecReader.ts
@@ -1,11 +1,6 @@
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
-import {
-  DependencySection,
-  Packages,
-  PackageVersionInfo,
-  Pubspec
-} from './interfaces'
+import {Packages, PackageVersionInfo, Pubspec} from './interfaces'
 
 export function getCurrentPackages(): Packages {
   const pathToPubSpec = './pubspec.yaml'
@@ -21,7 +16,9 @@ export function getCurrentPackages(): Packages {
   }
 }
 
-function parseIntoDependencySection(dependencies: object): DependencySection {
+function parseIntoDependencySection(
+  dependencies: object
+): PackageVersionInfo[] {
   const packageNameToSkip = ['flutter', 'footer', 'flutter_test']
 
   const dependencySection = []
@@ -39,7 +36,11 @@ function parseIntoDependencySection(dependencies: object): DependencySection {
   return dependencySection
 }
 
-export function readYaml(pathToYamlFile: string): Pubspec {
+export function readPubspec(): Pubspec {
+  return readYaml('./pubspec.yaml')
+}
+
+function readYaml(pathToYamlFile: string): Pubspec {
   let doc
 
   try {

--- a/src/pubspecUpdater.ts
+++ b/src/pubspecUpdater.ts
@@ -1,6 +1,24 @@
 import {Packages, PackageVersionInfo, Pubspec} from './interfaces'
 
-export function udpatePubspecDependencies(
+export function updatePubspecToResolvableVersion(
+  pubspec: Pubspec,
+  outdatedPackages: Packages
+): Pubspec {
+  let updatedPubspec = copyOfPubspec(pubspec)
+
+  updatedPubspec = updatePubspecDependencies(
+    pubspec,
+    outdatedPackages.dependencies
+  )
+  updatedPubspec = updatePubspecDevDependencies(
+    pubspec,
+    outdatedPackages.devDependencies
+  )
+
+  return updatedPubspec
+}
+
+export function updatePubspecDependencies(
   pubspec: Pubspec,
   dependencies: PackageVersionInfo[]
 ): Pubspec {
@@ -56,24 +74,6 @@ export function updatePackageToResolvableVersion(
   } else {
     updatedPubspec.dependencies[packageName] = newVersion
   }
-
-  return updatedPubspec
-}
-
-export function updatePubspecToResolvableVersion(
-  pubspec: Pubspec,
-  outdatedPackages: Packages
-): Pubspec {
-  let updatedPubspec = copyOfPubspec(pubspec)
-
-  updatedPubspec = udpatePubspecDependencies(
-    pubspec,
-    outdatedPackages.dependencies
-  )
-  updatedPubspec = updatePubspecDevDependencies(
-    pubspec,
-    outdatedPackages.devDependencies
-  )
 
   return updatedPubspec
 }

--- a/src/pubspecUpdater.ts
+++ b/src/pubspecUpdater.ts
@@ -4,7 +4,8 @@ export function udpatePubspecDependencies(
   pubspec: Pubspec,
   dependencies: PackageVersionInfo[]
 ): Pubspec {
-  let updatedPubspec = Object.assign({}, pubspec)
+  let updatedPubspec = copyOfPubspec(pubspec)
+
   for (const packageInfo of dependencies) {
     updatedPubspec = updatePackageToResolvableVersion(
       updatedPubspec,
@@ -20,7 +21,7 @@ export function updatePubspecDevDependencies(
   pubspec: Pubspec,
   devDependencies: PackageVersionInfo[]
 ): Pubspec {
-  let updatedPubspec = Object.assign({}, pubspec)
+  let updatedPubspec = copyOfPubspec(pubspec)
 
   for (const packageInfo of devDependencies) {
     updatedPubspec = updatePackageToResolvableVersion(
@@ -48,7 +49,7 @@ export function updatePackageToResolvableVersion(
 
   const newVersion = `^${resolvableVersion}`
 
-  const updatedPubspec = Object.assign({}, pubspec)
+  const updatedPubspec = copyOfPubspec(pubspec)
 
   if (isDevDependencies) {
     updatedPubspec.dev_dependencies[packageName] = newVersion
@@ -57,4 +58,8 @@ export function updatePackageToResolvableVersion(
   }
 
   return updatedPubspec
+}
+
+function copyOfPubspec(pubspec: Pubspec): Pubspec {
+  return Object.assign({}, pubspec)
 }

--- a/src/pubspecUpdater.ts
+++ b/src/pubspecUpdater.ts
@@ -1,0 +1,26 @@
+import {Pubspec} from './interfaces'
+
+export function updatePackageToResolvableVersion(
+  pubspec: Pubspec,
+  packageName: string,
+  resolvableVersion: string,
+  isDevDependencies = false
+): Pubspec {
+  const packageNameToSkip = ['flutter', 'footer', 'flutter_test']
+
+  if (packageNameToSkip.includes(packageName)) {
+    return pubspec
+  }
+
+  const newVersion = `^${resolvableVersion}`
+
+  const updatedPubspec = Object.assign({}, pubspec)
+
+  if (isDevDependencies) {
+    updatedPubspec.dev_dependencies[packageName] = newVersion
+  } else {
+    updatedPubspec.dependencies[packageName] = newVersion
+  }
+
+  return updatedPubspec
+}

--- a/src/pubspecUpdater.ts
+++ b/src/pubspecUpdater.ts
@@ -1,4 +1,4 @@
-import {PackageVersionInfo, Pubspec} from './interfaces'
+import {Packages, PackageVersionInfo, Pubspec} from './interfaces'
 
 export function udpatePubspecDependencies(
   pubspec: Pubspec,
@@ -56,6 +56,24 @@ export function updatePackageToResolvableVersion(
   } else {
     updatedPubspec.dependencies[packageName] = newVersion
   }
+
+  return updatedPubspec
+}
+
+export function updatePubspecToResolvableVersion(
+  pubspec: Pubspec,
+  outdatedPackages: Packages
+): Pubspec {
+  let updatedPubspec = copyOfPubspec(pubspec)
+
+  updatedPubspec = udpatePubspecDependencies(
+    pubspec,
+    outdatedPackages.dependencies
+  )
+  updatedPubspec = updatePubspecDevDependencies(
+    pubspec,
+    outdatedPackages.devDependencies
+  )
 
   return updatedPubspec
 }

--- a/src/pubspecUpdater.ts
+++ b/src/pubspecUpdater.ts
@@ -1,4 +1,38 @@
-import {Pubspec} from './interfaces'
+import {PackageVersionInfo, Pubspec} from './interfaces'
+
+export function udpatePubspecDependencies(
+  pubspec: Pubspec,
+  dependencies: PackageVersionInfo[]
+): Pubspec {
+  let updatedPubspec = Object.assign({}, pubspec)
+  for (const packageInfo of dependencies) {
+    updatedPubspec = updatePackageToResolvableVersion(
+      updatedPubspec,
+      packageInfo.packageName,
+      packageInfo.resolvableVersion as string
+    )
+  }
+
+  return updatedPubspec
+}
+
+export function updatePubspecDevDependencies(
+  pubspec: Pubspec,
+  devDependencies: PackageVersionInfo[]
+): Pubspec {
+  let updatedPubspec = Object.assign({}, pubspec)
+
+  for (const packageInfo of devDependencies) {
+    updatedPubspec = updatePackageToResolvableVersion(
+      updatedPubspec,
+      packageInfo.packageName,
+      packageInfo.resolvableVersion as string,
+      true
+    )
+  }
+
+  return updatedPubspec
+}
 
 export function updatePackageToResolvableVersion(
   pubspec: Pubspec,


### PR DESCRIPTION
## Summary
Implemented functions to update `Pubspec` (read from `pubspec.yaml`) using the output from `$ flutter pub outdated`

## Details
- replace `DependencySection` with `PackageVersionInfo[]`
- `updatePubspecToResolvableVersion()` to update outdated packages' version to resolvableVersion
 
## Options
- [pubspec dependencies - Caret syntax](https://dart.dev/tools/pub/dependencies#caret-syntax)