### PR TITLE
Pubspec Writer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,23 +2,21 @@ import * as core from '@actions/core'
 import {getOutdatedPackages} from './outdated'
 import {getCurrentPackages, readPubspec} from './pubspecReader'
 import {updatePubspecToResolvableVersion} from './pubspecUpdater'
+import {writePubspec, writeYaml} from './pubspecWriter'
 
 async function run(): Promise<void> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const currentPackages = getCurrentPackages()
-
     // read pubspec.yaml
     const pubspec = readPubspec()
     // get outdated package
     const outdatedPackages = await getOutdatedPackages()
     // update pubspec
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const updatedPubspec = updatePubspecToResolvableVersion(
       pubspec,
       outdatedPackages
     )
-    // TODO: write to pubspec
+    // write to pubspec.yaml
+    writePubspec(updatedPubspec)
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core'
 import {getOutdatedPackages} from './outdated'
-import {getCurrentPackages, readPubspec} from './pubspecReader'
+import {readPubspec} from './pubspecReader'
 import {updatePubspecToResolvableVersion} from './pubspecUpdater'
-import {writePubspec, writeYaml} from './pubspecWriter'
+import {writePubspec} from './pubspecWriter'
 
 async function run(): Promise<void> {
   try {

--- a/src/pubspecReader.ts
+++ b/src/pubspecReader.ts
@@ -1,40 +1,6 @@
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
-import {Packages, PackageVersionInfo, Pubspec} from './interfaces'
-
-export function getCurrentPackages(): Packages {
-  const pathToPubSpec = './pubspec.yaml'
-
-  const pubspec = readYaml(pathToPubSpec)
-
-  const dependencies = parseIntoDependencySection(pubspec.dependencies)
-  const devDependencies = parseIntoDependencySection(pubspec.dev_dependencies)
-
-  return {
-    dependencies,
-    devDependencies
-  }
-}
-
-function parseIntoDependencySection(
-  dependencies: object
-): PackageVersionInfo[] {
-  const packageNameToSkip = ['flutter', 'footer', 'flutter_test']
-
-  const dependencySection = []
-
-  for (const [packageName, currentVersion] of Object.entries(dependencies)) {
-    if (!packageNameToSkip.includes(packageName)) {
-      const dependency: PackageVersionInfo = {
-        packageName,
-        currentVersion
-      }
-      dependencySection.push(dependency)
-    }
-  }
-
-  return dependencySection
-}
+import {Pubspec} from './interfaces'
 
 export function readPubspec(): Pubspec {
   return readYaml('./pubspec.yaml')

--- a/src/pubspecWriter.ts
+++ b/src/pubspecWriter.ts
@@ -6,7 +6,7 @@ export function writePubspec(pubspec: Pubspec): void {
   writeYaml(pubspec, './pubspec.yaml')
 }
 
-export function writeYaml(obj: object, pathToYamlFile: string): void {
+function writeYaml(obj: object, pathToYamlFile: string): void {
   try {
     const output = yaml.dump(obj)
     fs.writeFileSync(pathToYamlFile, output)

--- a/src/pubspecWriter.ts
+++ b/src/pubspecWriter.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs'
+import * as yaml from 'js-yaml'
+import {Pubspec} from './interfaces'
+
+export function writePubspec(pubspec: Pubspec): void {
+  writeYaml(pubspec, './pubspec.yaml')
+}
+
+export function writeYaml(obj: object, pathToYamlFile: string): void {
+  try {
+    const output = yaml.dump(obj)
+    fs.writeFileSync(pathToYamlFile, output)
+  } catch (error) {
+    throw Error(`
+    an error occured during writing of yaml file.
+    error: ${error}
+    `)
+  }
+}


### PR DESCRIPTION
## Summary
Implemented functions to turn updated `Pubspec` back into `pubspec.yaml` using `js-yaml` package.

## Details

## Others
Dumping updated `pubspec` and writing it into `pubspec.yaml` will cause the comments written in the original `pubspec.yaml` to disappear as comments are ignored / skipped during reading of yaml file.
Now I kind of understand why most automatic updates choose to update `.lock` file as they are more structure and no comments are allow. Not sure if there's any method to update `pubspec.yaml` without removing the comments and white spaces.